### PR TITLE
fix: support package-prefixed tags in changelog header regex

### DIFF
--- a/helm-repo/action.yaml
+++ b/helm-repo/action.yaml
@@ -196,7 +196,7 @@ runs:
         fi
         echo "📌 Replacing version header"
         # Find the line with the version header, allowing for an optional 'v' prefix
-        HEADER_LINE=$(grep -nE "^## \[(v)?[0-9]+\.[0-9]+\.[0-9]+.*] - " $CHANGELOG_TARGET_PATH | head -n 1 | cut -d: -f1)
+        HEADER_LINE=$(grep -nE "^## \[([a-zA-Z0-9_-]+-)?(v)?[0-9]+\.[0-9]+\.[0-9]+.*] - " $CHANGELOG_TARGET_PATH | head -n 1 | cut -d: -f1)
         
         if [ -n "$HEADER_LINE" ]; then
           echo "📍 Header found on line: $HEADER_LINE"


### PR DESCRIPTION
## Summary
- Updated the grep regex in the "Replace version header" step to accept an optional package prefix (e.g., `sindarian-ui-`) before the version number
- Fixes changelog generation for monorepo tags like `sindarian-ui-v1.0.0-beta.42`
- Fully retrocompatible — tags without prefix continue to work

## Change
```diff
- grep -nE "^## \[(v)?[0-9]+\.[0-9]+\.[0-9]+.*] - "
+ grep -nE "^## \[([a-zA-Z0-9_-]+-)?(v)?[0-9]+\.[0-9]+\.[0-9]+.*] - "
```

## Test plan
- [ ] Verify changelog generation with prefixed tags (e.g., `sindarian-ui-v1.0.0-beta.42`)
- [ ] Verify changelog generation with non-prefixed tags (e.g., `v1.0.0`)